### PR TITLE
Pass scrubbed file name to Evaporate config

### DIFF
--- a/s3upload.js
+++ b/s3upload.js
@@ -65,7 +65,7 @@ S3Upload.prototype.uploadToS3 = function(file) {
     });
     return Evaporate.create(evaporateOptions).then(function(evaporate){
       var addConfig = {
-        name: this.s3Path + file.name,
+        name: this.s3Path + this.scrubFilename(file.name),
         file: file,
         progress: function(progressValue, stats){
           return this.onProgress(progressValue, progressValue === 100 ? 'Finalizing' : 'Uploading', file, stats);
@@ -100,7 +100,7 @@ S3Upload.prototype.uploadFile = function(file) {
 S3Upload.prototype.abortUpload = function(filename) {
   if (filename !== undefined){
     return this.evaporate && this.evaporate.cancel(
-      this.evaporateOptions.bucket + '/' + this.s3Path + filename
+      this.evaporateOptions.bucket + '/' + this.s3Path + this.scrubFilename(filename)
     );
   }else{
     return this.evaporate && this.evaporate.cancel();


### PR DESCRIPTION
I'm experiencing an issue where the files I'm expecting to be in S3 can't be found. I've traced the source of this issue to the fact that we aren't scrubbing the file name when uploading to S3. This differs from the mainline react-s3-uploader, which calls `scrubFilename()` in various places: https://github.com/odysseyscience/react-s3-uploader/blob/master/s3upload.js